### PR TITLE
[ToDo] Allow for Discord timestamps to be toggleable

### DIFF
--- a/todo/commands/todo_settings.py
+++ b/todo/commands/todo_settings.py
@@ -61,6 +61,14 @@ class Settings(ToDoMixin):
         already_set = f"Combined lists are already {toggled}"
         await self._toggler(ctx, toggle, "combined_lists", msg, already_set)
 
+    @todo_set.command(usage="<combine lists>")
+    async def timestamp(self, ctx, toggle: bool):
+        """Toggle for Discord timestamps to be shown in `[p]todo add`."""
+        toggled = get_toggle(toggle)
+        msg = f"Combined lists are now {toggled}"
+        already_set = f"Combined lists are already {toggled}"
+        await self._toggler(ctx, toggle, "timestamp", msg, already_set)
+
     @todo_set.command(usage="<give more details>")
     async def details(self, ctx, toggle: bool):
         """Set your lists to give you extra details when adding and removing them"""

--- a/todo/commands/todo_settings.py
+++ b/todo/commands/todo_settings.py
@@ -61,12 +61,12 @@ class Settings(ToDoMixin):
         already_set = f"Combined lists are already {toggled}"
         await self._toggler(ctx, toggle, "combined_lists", msg, already_set)
 
-    @todo_set.command(usage="<combine lists>")
+    @todo_set.command(usage="<show timestamp>")
     async def timestamp(self, ctx, toggle: bool):
         """Toggle for Discord timestamps to be shown in `[p]todo add`."""
         toggled = get_toggle(toggle)
-        msg = f"Combined lists are now {toggled}"
-        already_set = f"Combined lists are already {toggled}"
+        msg = f"Timestamps are now {toggled}"
+        already_set = f"Timestamps are already {toggled}."
         await self._toggler(ctx, toggle, "timestamp", msg, already_set)
 
     @todo_set.command(usage="<give more details>")

--- a/todo/commands/todo_settings.py
+++ b/todo/commands/todo_settings.py
@@ -65,7 +65,7 @@ class Settings(ToDoMixin):
     async def timestamp(self, ctx, toggle: bool):
         """Toggle for Discord timestamps to be shown in `[p]todo add`."""
         toggled = get_toggle(toggle)
-        msg = f"Timestamps are now {toggled}"
+        msg = f"Timestamps are now {toggled}."
         already_set = f"Timestamps are already {toggled}."
         await self._toggler(ctx, toggle, "timestamp", msg, already_set)
 

--- a/todo/todo.py
+++ b/todo/todo.py
@@ -39,6 +39,7 @@ _config_structure = {
     "combined_lists": False,
     "private": False,
     "colour": None,
+    "timestamp": True,
 }
 
 
@@ -243,15 +244,14 @@ class ToDo(
         try:
             conf["todos"].append(todo)
         except KeyError:
-            conf["todos"] = [
-                todo,
-            ]
+            conf["todos"] = [todo]
 
         msg = "Added that as a todo"
         details = conf.get("detailed_pop", False)
         if details:
             msg += f"\n'{discord.utils.escape_markdown(todo)}'"
-        msg += f"\n<t:{round(datetime.now().timestamp())}>"
+        if conf["timestamp"]:
+            msg += f"\n<t:{round(datetime.now().timestamp())}>"
         await self._maybe_autosort(ctx)
         if len(msg) > 2000:
             await ctx.send_interactive(pagify(msg))


### PR DESCRIPTION
## Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New Feature
- [ ] Other

## Description of the changes

Allow for timestamps to be toggleable. For someone like myself who's not a massive fan of timestamps, I'd prefer for them to not be shown in the `[p]todo add` command. It would be nice for there to be a setting for this.
