### PR TITLE
[AdvancedInvite] Fix Member object in DMs

### DIFF
--- a/advancedinvite/advanced_invite.py
+++ b/advancedinvite/advanced_invite.py
@@ -157,8 +157,19 @@ class AdvancedInvite(commands.Cog):
             )
             if support is not None:
                 embed.add_field(name="Join the support server!", value=support)
+            
+            if isinstance(ctx.channel, dicord.DMChannel):
+                member_converter = commands.MemberConverter()
+                try:
+                    member = await member_converter.convert(ctx.author.id)
+                except commands.MemberNotFound:
+                    member = False
+            else:
+                member = ctx.author
+                
+            
             if (
-                ctx.author.mobile_status.value != "offline"
+                member and member.mobile_status.value != "offline"
                 and self._settings_cache["mobile_check"]
             ):
                 embed.add_field(name="Here's a link if you're on mobile", value=url)


### PR DESCRIPTION
## Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Other

## Description of the changes

The invite command errors if it is executed in DMs, and if the mobile setting is enabled. It's not possible to get status through the discord.User object, so it will need to be through a discord.Member object instead. If the member could not be found (which would probably be quite rare), then the mobile check setting won't be available, but its not like that's a massive issue in itself.

Thanks ItzXenonUnity | Lou#2369 for the report. I haven't tested this but I'm fairly confident it should work.