### PR TITLE
[AdvancedInvite] Fix AttributeError

### DIFF
--- a/advancedinvite/advanced_invite.py
+++ b/advancedinvite/advanced_invite.py
@@ -35,7 +35,7 @@ _config_structure = {
     "title": "Invite {bot_name}",
     "support_server": None,
     "footer": None,
-    "extra_links": False,
+    "extra_link": False,
     "support_server_emoji": {},
     "invite_emoji": {},
 }
@@ -329,7 +329,7 @@ class AdvancedInvite(commands.Cog):
         **Arguments**
             - `toggle` Whether the invite command's embed should have extra links.
         """
-        await self.config.extra_links.set(toggle)
+        await self.config.extra_link.set(toggle)
         now_no_longer = "now" if toggle else "no longer"
         await ctx.send(f"Extra links are {now_no_longer} enabled.")
 

--- a/advancedinvite/advanced_invite.py
+++ b/advancedinvite/advanced_invite.py
@@ -35,7 +35,7 @@ _config_structure = {
     "title": "Invite {bot_name}",
     "support_server": None,
     "footer": None,
-    "extra_link": False,
+    "extra_links": False,
     "support_server_emoji": {},
     "invite_emoji": {},
 }


### PR DESCRIPTION
## Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Other

## Description of the changes

This PR is to fix "AttributeError: 'extra_links' is not a valid registered Group or value." by changing "extra_link" in "_config_structure" to "extra_links"