### PR TITLE
Fix key error in CmdLogger

### DIFF
--- a/cmdlogger/core.py
+++ b/cmdlogger/core.py
@@ -207,7 +207,7 @@ class CmdLogger(commands.Cog):
         name = ctx.command.qualified_name
         if (
             not conf["log_all"]
-            and (conf["ignore_owners"] and await ctx.bot.is_owner(ctx.author))
+            and (conf["ignore_owner"] and await ctx.bot.is_owner(ctx.author))
             and ctx.command.qualified_name not in conf["commands"]
             and (ctx.cog is None or ctx.cog.qualified_name not in conf["cogs"])
         ):


### PR DESCRIPTION
## Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Other

## Description of the changes

Fixes this error

```
Jan 13 19:12:29 scyther python[824331]: Ignoring exception in on_command_completion
Jan 13 19:12:29 scyther python[824331]: Traceback (most recent call last):
Jan 13 19:12:29 scyther python[824331]:   File "/home/yamik/redenv/lib/python3.9/site-packages/discord/client.py", line 343, in _run_event
Jan 13 19:12:29 scyther python[824331]:     await coro(*args, **kwargs)
Jan 13 19:12:29 scyther python[824331]:   File "/home/yamik/reddata/cogs/CogManager/cogs/cmdlogger/core.py", line 210, in on_command_completion
Jan 13 19:12:29 scyther python[824331]:     and (conf["ignore_owners"] and await ctx.bot.is_owner(ctx.author))
Jan 13 19:12:29 scyther python[824331]: KeyError: 'ignore_owners'
```