### PR TITLE
Fix NameError in `[p]cyclestatus forcenext`

### DIFF
--- a/cyclestatus/cycle_status.py
+++ b/cyclestatus/cycle_status.py
@@ -231,7 +231,7 @@ class CycleStatus(commands.Cog):
             status = statuses[0]
             nl = 0
         await self.config.next_iter.set(nl + 1 if nl < len(statuses) else 0)
-        await self._status_add(status, use_help)
+        await self._status_add(status, await self.config.use_help())
         await ctx.tick()
 
     @status.command(name="usehelp")


### PR DESCRIPTION
## Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Other

## Description of the changes

This PR fixes possible NameError in `[p]cyclestatus forcenext` if there are more than 1 status set